### PR TITLE
Optimize navigation loading

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,8 +5,6 @@ import Navigation from "@/components/component/Navigation/Navigation";
 import Footer from "@/components/component/Footer/Footer";
 import DarkTheme from "@/components/component/DarkTheme/DarkTheme";
 import PageLoader from "@/components/component/Spinner/Spinner";
-import { getLyrics } from "@/service/allartists";
-import { ILyrics } from "@/models/IObjects";
 import SessionProviderWrapper from "@/components/component/SessionProviderWrapper";
 // const ico = require("../../public/tangkhullyrics.ico");
 
@@ -48,16 +46,14 @@ export const metadata: Metadata = {
       "lyrics, tangkhul, tangkhul lyrics, tangkhul laa, tangkhul laa lyrics",
   },
 };
-export const generateStaticParams = async () => {
-  const posts = await getLyrics();
-  return posts;
-};
-export default async function RootLayout({
+export const dynamic = "force-static";
+export const revalidate = 604800;
+
+export default function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  const lyrics: ILyrics[] = await getLyrics();
 
   return (
     <html lang="en">
@@ -65,7 +61,7 @@ export default async function RootLayout({
         <SessionProviderWrapper>
           <DarkTheme />
           <header>
-            <Navigation lyrics={lyrics} />
+            <Navigation />
           </header>
           <div>
             <PageLoader />

--- a/src/components/component/Navigation/Navigation.tsx
+++ b/src/components/component/Navigation/Navigation.tsx
@@ -4,20 +4,31 @@ import { Music2Icon, SearchIcon } from "lucide-react";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import React, { useState, useEffect, useMemo } from "react";
-import { debounce } from "lodash";
+import debounce from "lodash/debounce";
 import { ILyrics } from "@/models/IObjects";
 import { sanitizeAndDeduplicateHTML, slugMaker } from "@/lib/utils";
 import Form from "next/form";
 
-interface NavigationProps {
-  lyrics: ILyrics[];
-}
-
-const Navigation: React.FC<NavigationProps> = ({ lyrics }) => {
+const Navigation: React.FC = () => {
+  const [lyrics, setLyrics] = useState<ILyrics[]>([]);
   const [searchQuery, setSearchQuery] = useState("");
   const [filteredLyrics, setFilteredLyrics] = useState<ILyrics[]>([]);
   const router = useRouter();
   const pathname = usePathname();
+
+  useEffect(() => {
+    const fetchLyrics = async () => {
+      try {
+        const res = await fetch("/api/lyrics?sort=title");
+        if (res.ok) {
+          setLyrics(await res.json());
+        }
+      } catch (error) {
+        console.error("Failed to fetch lyrics", error);
+      }
+    };
+    fetchLyrics();
+  }, []);
   const searchIndex = useMemo(
     () =>
       lyrics.map((lyric) => ({


### PR DESCRIPTION
## Summary
- fetch lyrics client-side for navigation and use lodash/debounce for efficiency
- mark layout as static and revalidate weekly
- remove unused data fetching from layout

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*
- `npm run build` *(fails: next not found)*
- `npx tsc -p tsconfig.json` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_68503ad798788333858fc93bfa45ef6f