### PR TITLE
Enable static pages and client-based search

### DIFF
--- a/src/app/(pages)/home/page.tsx
+++ b/src/app/(pages)/home/page.tsx
@@ -8,6 +8,7 @@ import {
   getFeaturedLyrics,
   getTopLyrics,
 } from "@/service/allartists";
+export const dynamic = "force-static";
 export const revalidate = 604800;
 // ✅ Fetch all data in parallel
 const fetchHomeData = async () => {

--- a/src/app/(pages)/search/page.tsx
+++ b/src/app/(pages)/search/page.tsx
@@ -1,35 +1,16 @@
-import SearchResult from "@/components/component/SearchResult/SearchResult";
+import SearchClient from "@/components/component/SearchResult/SearchClient";
 import { generatePageMetadata } from "@/lib/utils";
-import { searchLyrics } from "@/service/allartists";
 
-export async function generateMetadata({
-  searchParams,
-}: {
-  searchParams: Promise<{ query?: string }>;
-}) {
-  const resolvedSearchParams = await searchParams;
-  const query = resolvedSearchParams.query?.toString() ?? "";
-  const formattedQuery = decodeURIComponent(query);
+export const dynamic = "force-static";
+export const revalidate = 60;
 
-  return generatePageMetadata({
-    title: `Search results for "${formattedQuery}"`,
-    description: `Find Tangkhul song lyrics related to "${formattedQuery}" on TangkhulLyrics.`,
-    url: `https://tangkhullyrics.com/search?query=${encodeURIComponent(query)}`,
-    keywords: `Tangkhul lyrics, Search lyrics, Tangkhul song lyrics, ${formattedQuery}, Tangkhul music`,
-  });
-}
+export const metadata = generatePageMetadata({
+  title: "Search Tangkhul Lyrics",
+  description: "Find Tangkhul song lyrics and artists.",
+  url: "https://tangkhullyrics.com/search",
+  keywords: "Tangkhul lyrics, Search lyrics, Tangkhul song lyrics, Tangkhul music",
+});
 
-export default async function SearchPage({
-  searchParams,
-}: {
-  searchParams: Promise<{ query?: string }>;
-}) {
-  const resolvedSearchParams = await searchParams;
-  const query = resolvedSearchParams.query?.toString() ?? "";
-  const formattedQuery = decodeURIComponent(query);
-  const lyrics = query
-    ? await searchLyrics(formattedQuery)
-    : await searchLyrics("kaphaning");
-
-  return <SearchResult params={query} lyrics={lyrics} />;
+export default function SearchPage() {
+  return <SearchClient />;
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,9 @@
 import HomePage from "./(pages)/home/page";
 // import RootLayout from "./layout";
 
+export const dynamic = "force-static";
+export const revalidate = 604800;
+
 export default function MainPage() {
   return <HomePage />;
 }

--- a/src/components/component/SearchResult/SearchClient.tsx
+++ b/src/components/component/SearchResult/SearchClient.tsx
@@ -1,0 +1,36 @@
+'use client'
+import { useEffect, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
+import { IArtists, ILyrics } from '@/models/IObjects';
+import SearchResult from './SearchResult';
+
+export default function SearchClient() {
+  const searchParams = useSearchParams();
+  const queryParam = searchParams.get('query') || '';
+  const query = decodeURIComponent(queryParam);
+  const [data, setData] = useState<{ lyrics: ILyrics[]; artists: IArtists[] }>({
+    lyrics: [],
+    artists: [],
+  });
+
+  useEffect(() => {
+    if (!query) {
+      setData({ lyrics: [], artists: [] });
+      return;
+    }
+    const fetchData = async () => {
+      try {
+        const res = await fetch(`/api/search?query=${encodeURIComponent(query)}`);
+        if (res.ok) {
+          const json = await res.json();
+          setData(json);
+        }
+      } catch (err) {
+        console.error('Search fetch failed', err);
+      }
+    };
+    fetchData();
+  }, [query]);
+
+  return <SearchResult params={query} lyrics={data} />;
+}

--- a/src/components/component/SearchResult/SearchResult.tsx
+++ b/src/components/component/SearchResult/SearchResult.tsx
@@ -1,3 +1,4 @@
+'use client';
 import {
   highlightFuzzyMatch,
   sanitizeAndDeduplicateHTML,


### PR DESCRIPTION
## Summary
- serve the homepage via static rendering
- switch the search page to a static shell and move searching to a client component
- allow the root page to be rendered statically

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_b_68503e78cd988333b065e84e4935f707