### PR TITLE
Add service worker offline caching for lyrics and browse/search data

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,148 +1,299 @@
 /*
-  Simple MVP Service Worker for Offline-First
-  - Caches visited pages and static assets
-  - Runtime caching for API responses
-  - Network-first for navigation with cache fallback
-  - Stale-while-revalidate for assets and API
+  Service Worker for Tangkhul Lyrics
+  - Caches visited lyrics/search pages for limited offline access
+  - Keeps A-Z browse and search API responses fast on slow networks
+  - Uses stale-while-revalidate for browse/query data and assets
+  - Uses network-first with cache fallback for lyrics detail pages
 */
 
-const VERSION = "v2.0.1";
+const VERSION = "v2.1.0";
 const PAGE_CACHE = `pages-${VERSION}`;
 const ASSET_CACHE = `assets-${VERSION}`;
-const API_CACHE = `api-${VERSION}`;
+const CONTENT_CACHE = `content-${VERSION}`;
+
+const MANAGED_CACHES = [PAGE_CACHE, ASSET_CACHE, CONTENT_CACHE];
+const CONTENT_CACHE_MAX_ENTRIES = 90;
+const PAGE_CACHE_MAX_ENTRIES = 60;
+const NETWORK_TIMEOUT_MS = 3000;
+
+const OFFLINE_RESPONSE = `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Offline | Tangkhul Lyrics</title>
+    <style>
+      body { font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; margin: 0; min-height: 100vh; display: grid; place-items: center; background: #0f172a; color: #f8fafc; }
+      main { max-width: 38rem; padding: 2rem; text-align: center; }
+      a { color: #bfdbfe; }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>You are offline</h1>
+      <p>Previously visited lyrics, search, and browse pages are available from cache. Reconnect to load new songs.</p>
+      <p><a href="/lyrics">Try cached lyrics</a></p>
+    </main>
+  </body>
+</html>`;
 
 self.addEventListener("install", (event) => {
-  // Skip waiting for quicker updates during development
-  self.skipWaiting();
+  event.waitUntil(
+    (async () => {
+      const cache = await caches.open(PAGE_CACHE);
+      await cache
+        .addAll(["/", "/lyrics"])
+        .catch(() => {
+          // Precache is a best-effort warm-up; runtime caching handles failures.
+        });
+      await self.skipWaiting();
+    })()
+  );
 });
 
 self.addEventListener("activate", (event) => {
   event.waitUntil(
     (async () => {
-      // Clean up old caches
       const keys = await caches.keys();
       await Promise.all(
         keys
-          .filter((k) => ![PAGE_CACHE, ASSET_CACHE, API_CACHE].includes(k))
-          .map((k) => caches.delete(k))
+          .filter((key) => !MANAGED_CACHES.includes(key))
+          .map((key) => caches.delete(key))
       );
-      // Take control immediately
       await self.clients.claim();
     })()
   );
 });
 
-function isSameOrigin(url) {
+function isSameOrigin(requestUrl) {
   try {
-    const u = new URL(url);
-    return u.origin === self.location.origin;
+    return new URL(requestUrl).origin === self.location.origin;
   } catch {
     return false;
   }
 }
 
-self.addEventListener("fetch", (event) => {
-  const { request } = event;
+function isStaticAsset(url) {
+  return (
+    /\.(?:js|css|svg|png|jpg|jpeg|gif|webp|avif|ico|woff2?|ttf|otf)$/i.test(
+      url.pathname
+    ) ||
+    url.pathname.startsWith("/_next/") ||
+    url.pathname === "/manifest.json"
+  );
+}
+
+function isPublicNavigationPath(pathname) {
+  return (
+    pathname === "/" ||
+    pathname === "/home" ||
+    pathname === "/lyrics" ||
+    pathname.startsWith("/lyrics/") ||
+    pathname === "/artists" ||
+    pathname.startsWith("/artists/") ||
+    pathname === "/allartists" ||
+    pathname === "/search"
+  );
+}
+
+function isLyricsDetailPath(pathname) {
+  return /^\/lyrics\/[^/]+\/[^/]+\/?$/.test(pathname);
+}
+
+function isBrowseOrQueryApi(url) {
+  if (url.pathname === "/api/search") {
+    return Boolean(url.searchParams.get("query")?.trim());
+  }
+
+  if (url.pathname === "/api/lyrics") {
+    return !url.searchParams.has("includeAll");
+  }
+
+  if (url.pathname === "/api/artist") {
+    return true;
+  }
+
+  if (url.pathname === "/api/artist/lyricscount") {
+    return true;
+  }
+
+  if (url.pathname === "/api/lyrics/author/lyrics") {
+    return Boolean(url.searchParams.get("artistName")?.trim());
+  }
+
+  return false;
+}
+
+function shouldBypassCache(request, url) {
+  return (
+    request.cache === "no-store" ||
+    url.searchParams.has("_cacheBust") ||
+    url.pathname.startsWith("/api/auth") ||
+    url.pathname.startsWith("/api/admin") ||
+    url.pathname.startsWith("/admin")
+  );
+}
+
+function cacheKeyForRequest(request) {
   const url = new URL(request.url);
 
-  // Only handle GET
-  if (request.method !== "GET") return;
-
-  // Navigation requests: Network-first with cache fallback
-  if (request.mode === "navigate") {
-    event.respondWith(
-      (async () => {
-        try {
-          const networkResponse = await fetch(request);
-          const cache = await caches.open(PAGE_CACHE);
-          // Clone and store in cache
-          cache.put(request, networkResponse.clone()).catch(() => {});
-          return networkResponse;
-        } catch (err) {
-          // Fallback to cache when offline
-          const cacheResponse = await caches.match(request);
-          if (cacheResponse) return cacheResponse;
-          // If not cached, try serving the root page if available
-          const fallback = await caches.match("/");
-          return fallback || new Response("Offline", { status: 503 });
-        }
-      })()
-    );
-    return;
-  }
-
-  // Static assets: Stale-while-revalidate
-  if (
-    isSameOrigin(request.url) &&
-    (/\.(?:js|css|svg|png|jpg|jpeg|gif|webp|ico|woff2?)$/i.test(url.pathname) ||
-      url.pathname.startsWith("/_next/") ||
-      url.pathname.startsWith("/public/"))
-  ) {
-    event.respondWith(
-      (async () => {
-        const cache = await caches.open(ASSET_CACHE);
-        const cached = await cache.match(request);
-        const networkPromise = fetch(request)
-          .then((res) => {
-            cache.put(request, res.clone()).catch(() => {});
-            return res;
-          })
-          .catch(() => null);
-        return (
-          cached ||
-          networkPromise ||
-          new Response("Offline asset", { status: 503 })
-        );
-      })()
-    );
-    return;
-  }
-
-  function isContentApi(pathname) {
-    return (
-      pathname.startsWith("/api/lyrics") ||
-      pathname.startsWith("/api/artist") ||
-      pathname.startsWith("/api/search")
+  if (url.pathname === "/api/search") {
+    const query = url.searchParams.get("query")?.trim().toLowerCase() ?? "";
+    const limit = url.searchParams.get("limit") ?? "";
+    return new Request(
+      `${url.origin}${url.pathname}?query=${encodeURIComponent(query)}${
+        limit ? `&limit=${encodeURIComponent(limit)}` : ""
+      }`
     );
   }
 
-  // Content API responses: network-first with a short timeout and cache fallback.
-  // The app-level IndexedDB cache still controls instant repeat renders.
-  if (isSameOrigin(request.url) && url.pathname.startsWith("/api/")) {
-    if (request.cache === "no-store" || url.searchParams.has("_cacheBust")) {
-      event.respondWith(fetch(request));
-      return;
+  return request;
+}
+
+function isCacheableResponse(response) {
+  if (!response || !response.ok) return false;
+  if (response.type === "opaque") return false;
+
+  return true;
+}
+
+async function trimCache(cacheName, maxEntries) {
+  const cache = await caches.open(cacheName);
+  const keys = await cache.keys();
+  if (keys.length <= maxEntries) return;
+
+  await Promise.all(
+    keys.slice(0, keys.length - maxEntries).map((request) => cache.delete(request))
+  );
+}
+
+async function putInCache(cacheName, request, response, maxEntries) {
+  if (!isCacheableResponse(response)) return;
+
+  const cache = await caches.open(cacheName);
+  await cache.put(request, response.clone()).catch(() => {});
+  await trimCache(cacheName, maxEntries).catch(() => {});
+}
+
+function fetchWithTimeout(request, timeoutMs = NETWORK_TIMEOUT_MS) {
+  return Promise.race([
+    fetch(request),
+    new Promise((resolve) => setTimeout(() => resolve(null), timeoutMs)),
+  ]);
+}
+
+async function networkFirstWithCacheFallback(request, options = {}) {
+  const {
+    cacheName = PAGE_CACHE,
+    timeoutMs = NETWORK_TIMEOUT_MS,
+    maxEntries = PAGE_CACHE_MAX_ENTRIES,
+    fallbackRequest,
+  } = options;
+
+  const cacheKey = cacheKeyForRequest(request);
+  const fallbackKey = fallbackRequest ? cacheKeyForRequest(fallbackRequest) : null;
+  const cache = await caches.open(cacheName);
+
+  try {
+    const response = await fetchWithTimeout(request, timeoutMs);
+    if (response) {
+      await putInCache(cacheName, cacheKey, response.clone(), maxEntries);
+      return response;
     }
+  } catch {
+    // Network failures fall through to cached content.
+  }
+
+  const cached = await cache.match(cacheKey);
+  if (cached) return cached;
+
+  if (fallbackKey) {
+    const fallback = await cache.match(fallbackKey);
+    if (fallback) return fallback;
+  }
+
+  try {
+    const response = await fetch(request);
+    await putInCache(cacheName, cacheKey, response.clone(), maxEntries);
+    return response;
+  } catch {
+    const rootFallback = await cache.match("/");
+    return (
+      rootFallback ||
+      new Response(OFFLINE_RESPONSE, {
+        status: 503,
+        headers: { "Content-Type": "text/html; charset=utf-8" },
+      })
+    );
+  }
+}
+
+async function staleWhileRevalidate(request, cacheName, maxEntries) {
+  const cacheKey = cacheKeyForRequest(request);
+  const cache = await caches.open(cacheName);
+  const cached = await cache.match(cacheKey);
+
+  const networkPromise = fetch(request)
+    .then(async (response) => {
+      await putInCache(cacheName, cacheKey, response.clone(), maxEntries);
+      return response;
+    })
+    .catch(() => null);
+
+  return (
+    cached ||
+    (await networkPromise) ||
+    new Response(JSON.stringify({ offline: true, cached: false }), {
+      status: 200,
+      headers: { "Content-Type": "application/json; charset=utf-8" },
+    })
+  );
+}
+
+self.addEventListener("fetch", (event) => {
+  const { request } = event;
+
+  if (request.method !== "GET" || !isSameOrigin(request.url)) return;
+
+  const url = new URL(request.url);
+  if (shouldBypassCache(request, url)) return;
+
+  if (request.mode === "navigate") {
+    if (!isPublicNavigationPath(url.pathname)) return;
 
     event.respondWith(
-      (async () => {
-        const cache = await caches.open(API_CACHE);
-        const cached = await cache.match(request);
-        const timeoutMs = isContentApi(url.pathname) ? 2500 : 800;
-        const timeout = new Promise((resolve) =>
-          setTimeout(() => resolve(null), timeoutMs)
-        );
-        const networkPromise = fetch(request).then(async (res) => {
-          if (res && res.ok) {
-            await cache.put(request, res.clone()).catch(() => {});
-          }
-          return res;
-        });
-        const networkResponse = await Promise.race([
-          networkPromise.catch(() => null),
-          timeout,
-        ]);
-        return (
-          networkResponse ||
-          cached ||
-          (await networkPromise.catch(() => null)) ||
-          new Response(JSON.stringify({ offline: true }), {
-            status: 200,
-            headers: { "Content-Type": "application/json" },
-          })
-        );
-      })()
+      networkFirstWithCacheFallback(request, {
+        cacheName: PAGE_CACHE,
+        timeoutMs: isLyricsDetailPath(url.pathname) ? 4000 : NETWORK_TIMEOUT_MS,
+        maxEntries: PAGE_CACHE_MAX_ENTRIES,
+        fallbackRequest:
+          url.pathname === "/search"
+            ? new Request(`${self.location.origin}/lyrics`)
+            : undefined,
+      })
     );
     return;
+  }
+
+  if (isStaticAsset(url)) {
+    event.respondWith(staleWhileRevalidate(request, ASSET_CACHE, 120));
+    return;
+  }
+
+  if (isBrowseOrQueryApi(url)) {
+    event.respondWith(
+      staleWhileRevalidate(request, CONTENT_CACHE, CONTENT_CACHE_MAX_ENTRIES)
+    );
+    return;
+  }
+
+  if (url.pathname.startsWith("/api/lyrics/author/singleLyrics")) {
+    event.respondWith(
+      networkFirstWithCacheFallback(request, {
+        cacheName: CONTENT_CACHE,
+        timeoutMs: 3500,
+        maxEntries: CONTENT_CACHE_MAX_ENTRIES,
+      })
+    );
   }
 });


### PR DESCRIPTION
### Motivation
- Provide limited offline access and faster repeat loads by caching lyrics pages and A–Z browse / search API responses for users on slow or intermittent networks.
- Keep runtime cache usage bounded and safe to avoid unbounded storage growth on clients.

### Description
- Replace the previous SW with a new `public/sw.js` that introduces versioned `pages`, `assets`, and `content` caches and performs cleanup of old caches on activation.
- Use network-first with cache-fallback for navigation and lyrics detail pages (with a small network timeout) and serve an HTML offline fallback when nothing is cached.
- Use stale-while-revalidate for static assets and for browse/query API endpoints (e.g. `/api/lyrics`, `/api/search`, artist endpoints and artist-lyrics queries) and normalize cache keys for search queries to improve cache hits.
- Add pre-cache warm-up of `/` and `/lyrics`, cache trimming (max entries) and safe bypass rules for `no-store`, `_cacheBust`, admin/auth routes, while preserving existing client-side SW registration/error handling components.

### Testing
- `node --check public/sw.js` — passed and confirmed the service worker file is syntactically valid.
- `npm run lint` — passed (ESLint run completed with no SW-related errors reported).
- `npm run build` — attempted but failed in this environment because Next.js could not fetch the Google `Inter` font during the build; this is an environment/network issue unrelated to the SW logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00aeac99e88323b83531b17ef3dfb8)